### PR TITLE
Corrigir cores de fundo na paleta de cores

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,35 +74,35 @@
         </div>
         <div class="color-palette">
           <div class="color-item">
-            <div class="color" data-color="#000000"></div>
+            <div class="color" data-color="#000000" style="background-color: #000000;"></div>
             <span class="color-label">Preto</span>
           </div>
           <div class="color-item">
-            <div class="color" data-color="#FF0000"></div>
+            <div class="color" data-color="#FF0000" style="background-color: #FF0000;"></div>
             <span class="color-label">Vermelho</span>
           </div>
           <div class="color-item">
-            <div class="color" data-color="#00FF00"></div>
+            <div class="color" data-color="#00FF00" style="background-color: #00FF00;"></div>
             <span class="color-label">Verde</span>
           </div>
           <div class="color-item">
-            <div class="color" data-color="#0000FF"></div>
+            <div class="color" data-color="#0000FF" style="background-color: #0000FF;"></div>
             <span class="color-label">Azul</span>
           </div>
           <div class="color-item">
-            <div class="color" data-color="#FFFF00"></div>
+            <div class="color" data-color="#FFFF00" style="background-color: #FFFF00;"></div>
             <span class="color-label">Amarelo</span>
           </div>
           <div class="color-item">
-            <div class="color" data-color="#FF00FF"></div>
+            <div class="color" data-color="#FF00FF" style="background-color: #FF00FF;"></div>
             <span class="color-label">Magenta</span>
           </div>
           <div class="color-item">
-            <div class="color" data-color="#00FFFF"></div>
+            <div class="color" data-color="#00FFFF" style="background-color: #00FFFF;"></div>
             <span class="color-label">Ciano</span>
           </div>
           <div class="color-item">
-            <div class="color" data-color="#FFFFFF"></div>
+            <div class="color" data-color="#FFFFFF" style="background-color: #FFFFFF;"></div>
             <span class="color-label">Branco</span>
           </div>
         </div>


### PR DESCRIPTION
- Corrige as cores de fundo que não estavam aparecendo na paleta
- Adiciona style='background-color' para cada cor ficar visível
- Complementa a PR anterior que foi mergeada
- Agora todas as cores (preto, vermelho, verde, azul, amarelo, magenta, ciano, branco) aparecem corretamente
- Melhora a experiência visual do usuário