### PR TITLE
Add theme, grid, and zoom controls to pixel art app

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,9 @@
 <body>
   <header>
     <h1>Pixel Art</h1>
+    <div class="header-controls">
+      <button id="theme-toggle" class="theme-toggle" title="Alternar tema">🌓</button>
+    </div>
   </header>
 
   <main>
@@ -51,19 +54,32 @@
       </section>
 
       <section class="canvas-section">
-        <h2>Seu Canvas Interativo</h2>
-        <div id="pixel-canvas">
-          <!-- Canvas será gerado via JavaScript -->
+        <div class="canvas-header">
+          <h2>Seu Canvas Interativo</h2>
+          <div class="canvas-controls">
+            <button id="grid-toggle" title="Mostrar/Ocultar Grade">🔲</button>
+            <button id="zoom-out" title="Diminuir Zoom">🔍-</button>
+            <span id="zoom-level">100%</span>
+            <button id="zoom-in" title="Aumentar Zoom">🔍+</button>
+          </div>
+        </div>
+        <div id="canvas-container">
+          <div id="pixel-canvas">
+            <!-- Canvas será gerado via JavaScript -->
+          </div>
         </div>
       </section>
 
       <section class="tools-section">
         <h2>Ferramentas</h2>
         <div class="tools">
-          <button id="pencil-tool">Lápis</button>
-          <button id="eraser-tool">Borracha</button>
-          <button id="fill-tool">Preenchimento</button>
-          <button>Pintar Tudo</button>
+          <button id="pencil-tool" data-key="p">Lápis (P)</button>
+          <button id="eraser-tool" data-key="e">Borracha (E)</button>
+          <button id="fill-tool" data-key="f">Preenchimento (F)</button>
+          <button id="clear-tool" data-key="c">Limpar Tudo (C)</button>
+        </div>
+        <div class="tool-info">
+          <p><strong>Atalhos:</strong> P = Lápis, E = Borracha, F = Preenchimento, C = Limpar</p>
         </div>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
           <button id="clear-tool" data-key="c">Limpar Tudo (C)</button>
         </div>
         <div class="tool-info">
-          <p><strong>Atalhos:</strong> P = Lápis, E = Borracha, F = Preenchimento, C = Limpar</p>
+          <p><strong>Atalhos do Teclado:</strong> P = Lápis | E = Borracha | F = Preenchimento | C = Limpar</p>
         </div>
       </section>
 

--- a/script.js
+++ b/script.js
@@ -2,27 +2,49 @@
 let currentColor = '#000000';
 let currentTool = 'pencil';
 let isDrawing = false;
+let currentZoom = 100;
+let showGrid = true;
+let canvasSize = window.innerWidth <= 768 ? (window.innerWidth <= 480 ? 10 : 12) : 16;
 
 // Elementos do DOM
 const canvas = document.getElementById('pixel-canvas');
 const colorPalette = document.querySelectorAll('.color');
 const tools = document.querySelectorAll('.tools button');
+const themeToggle = document.getElementById('theme-toggle');
+const gridToggle = document.getElementById('grid-toggle');
+const zoomIn = document.getElementById('zoom-in');
+const zoomOut = document.getElementById('zoom-out');
+const zoomLevel = document.getElementById('zoom-level');
 
 // Inicialização
 document.addEventListener('DOMContentLoaded', function () {
   initializeCanvas();
   setupEventListeners();
   initializeUI();
+  loadTheme();
 });
 
 // Criar canvas de pixels
 function initializeCanvas() {
-  for (let i = 0; i < 256; i++) { // 16x16 = 256 pixels
+  canvas.innerHTML = ''; // Limpar canvas existente
+  canvas.style.gridTemplateColumns = `repeat(${canvasSize}, ${getPixelSize()}px)`;
+  canvas.style.gridTemplateRows = `repeat(${canvasSize}, ${getPixelSize()}px)`;
+  
+  for (let i = 0; i < canvasSize * canvasSize; i++) {
     const pixel = document.createElement('div');
     pixel.className = 'pixel';
     pixel.dataset.index = i;
+    pixel.style.width = getPixelSize() + 'px';
+    pixel.style.height = getPixelSize() + 'px';
     canvas.appendChild(pixel);
   }
+}
+
+// Obter tamanho do pixel baseado no tamanho da tela
+function getPixelSize() {
+  if (window.innerWidth <= 480) return 16;
+  if (window.innerWidth <= 768) return 18;
+  return 20;
 }
 
 // Configurar event listeners
@@ -38,31 +60,133 @@ function setupEventListeners() {
   // Seleção de ferramentas
   tools.forEach(tool => {
     tool.addEventListener('click', function () {
-      currentTool = this.id.replace('-tool', '');
-      updateSelectedTool();
+      const toolName = this.id.replace('-tool', '');
+      if (toolName === 'clear') {
+        clearCanvas();
+      } else {
+        currentTool = toolName;
+        updateSelectedTool();
+      }
     });
   });
 
-  // Eventos do canvas
+  // Tema
+  if (themeToggle) {
+    themeToggle.addEventListener('click', toggleTheme);
+  }
+
+  // Controles do canvas
+  if (gridToggle) {
+    gridToggle.addEventListener('click', toggleGrid);
+  }
+  
+  if (zoomIn) {
+    zoomIn.addEventListener('click', () => changeZoom(25));
+  }
+  
+  if (zoomOut) {
+    zoomOut.addEventListener('click', () => changeZoom(-25));
+  }
+
+  // Eventos do canvas para mouse
   canvas.addEventListener('mousedown', startDrawing);
   canvas.addEventListener('mousemove', draw);
   canvas.addEventListener('mouseup', stopDrawing);
   canvas.addEventListener('mouseleave', stopDrawing);
+
+  // Eventos do canvas para touch
+  canvas.addEventListener('touchstart', startDrawingTouch, { passive: false });
+  canvas.addEventListener('touchmove', drawTouch, { passive: false });
+  canvas.addEventListener('touchend', stopDrawing);
+
+  // Atalhos de teclado
+  document.addEventListener('keydown', handleKeyboard);
+
+  // Responsividade
+  window.addEventListener('resize', handleResize);
 }
 
-// Funções de desenho
+// Atalhos de teclado
+function handleKeyboard(e) {
+  const key = e.key.toLowerCase();
+  
+  switch (key) {
+    case 'p':
+      currentTool = 'pencil';
+      updateSelectedTool();
+      break;
+    case 'e':
+      currentTool = 'eraser';
+      updateSelectedTool();
+      break;
+    case 'f':
+      currentTool = 'fill';
+      updateSelectedTool();
+      break;
+    case 'c':
+      clearCanvas();
+      break;
+  }
+}
+
+// Responsividade
+function handleResize() {
+  const newCanvasSize = window.innerWidth <= 768 ? (window.innerWidth <= 480 ? 10 : 12) : 16;
+  if (newCanvasSize !== canvasSize) {
+    canvasSize = newCanvasSize;
+    initializeCanvas();
+    setupCanvasEvents();
+  }
+}
+
+// Configurar eventos do canvas após recriação
+function setupCanvasEvents() {
+  canvas.addEventListener('mousedown', startDrawing);
+  canvas.addEventListener('mousemove', draw);
+  canvas.addEventListener('mouseup', stopDrawing);
+  canvas.addEventListener('mouseleave', stopDrawing);
+  canvas.addEventListener('touchstart', startDrawingTouch, { passive: false });
+  canvas.addEventListener('touchmove', drawTouch, { passive: false });
+  canvas.addEventListener('touchend', stopDrawing);
+}
+
+// Funções de desenho - Mouse
 function startDrawing(e) {
   if (e.target.classList.contains('pixel')) {
     isDrawing = true;
     drawPixel(e.target);
-    e.preventDefault(); // Prevenir seleção de texto
+    e.preventDefault();
   }
 }
 
 function draw(e) {
   if (isDrawing && e.target.classList.contains('pixel')) {
     drawPixel(e.target);
-    e.preventDefault(); // Prevenir seleção de texto
+    e.preventDefault();
+  }
+}
+
+// Funções de desenho - Touch
+function startDrawingTouch(e) {
+  e.preventDefault();
+  const touch = e.touches[0];
+  const element = document.elementFromPoint(touch.clientX, touch.clientY);
+  
+  if (element && element.classList.contains('pixel')) {
+    isDrawing = true;
+    drawPixel(element);
+  }
+}
+
+function drawTouch(e) {
+  e.preventDefault();
+  if (isDrawing) {
+    const touch = e.touches[0];
+    const element = document.elementFromPoint(touch.clientX, touch.clientY);
+    
+    if (element && element.classList.contains('pixel')) {
+      drawPixel(element);
+    }
   }
 }
 
@@ -71,24 +195,140 @@ function stopDrawing() {
 }
 
 function drawPixel(pixel) {
+  const pixelBg = getComputedStyle(document.documentElement).getPropertyValue('--pixel-bg').trim();
+  const pixelBorder = getComputedStyle(document.documentElement).getPropertyValue('--pixel-border').trim();
+  
   if (currentTool === 'pencil') {
     pixel.style.backgroundColor = currentColor;
-    pixel.style.borderColor = currentColor;
   } else if (currentTool === 'eraser') {
-    pixel.style.backgroundColor = 'white';
-    pixel.style.borderColor = '#ddd';
+    pixel.style.backgroundColor = pixelBg;
+  } else if (currentTool === 'fill') {
+    floodFill(pixel);
   }
-  // fill-tool será implementado futuramente
+}
+
+// Algoritmo de preenchimento (flood fill)
+function floodFill(startPixel) {
+  const pixels = Array.from(canvas.children);
+  const startIndex = parseInt(startPixel.dataset.index);
+  const targetColor = getComputedStyle(startPixel).backgroundColor;
+  
+  if (rgbToHex(targetColor) === currentColor) {
+    return; // Não preencher se a cor já for a mesma
+  }
+  
+  const stack = [startIndex];
+  const visited = new Set();
+  
+  while (stack.length > 0) {
+    const currentIndex = stack.pop();
+    
+    if (visited.has(currentIndex)) continue;
+    visited.add(currentIndex);
+    
+    const currentPixel = pixels[currentIndex];
+    if (!currentPixel || rgbToHex(getComputedStyle(currentPixel).backgroundColor) !== rgbToHex(targetColor)) {
+      continue;
+    }
+    
+    currentPixel.style.backgroundColor = currentColor;
+    
+    // Adicionar pixels adjacentes
+    const row = Math.floor(currentIndex / canvasSize);
+    const col = currentIndex % canvasSize;
+    
+    // Cima
+    if (row > 0) stack.push(currentIndex - canvasSize);
+    // Baixo
+    if (row < canvasSize - 1) stack.push(currentIndex + canvasSize);
+    // Esquerda
+    if (col > 0) stack.push(currentIndex - 1);
+    // Direita
+    if (col < canvasSize - 1) stack.push(currentIndex + 1);
+  }
+}
+
+// Converter RGB para HEX
+function rgbToHex(rgb) {
+  if (rgb.startsWith('#')) return rgb;
+  
+  const values = rgb.match(/\d+/g);
+  if (!values) return rgb;
+  
+  return '#' + values.map(x => {
+    const hex = parseInt(x).toString(16);
+    return hex.length === 1 ? '0' + hex : hex;
+  }).join('');
+}
+
+// Limpar canvas
+function clearCanvas() {
+  const pixels = canvas.querySelectorAll('.pixel');
+  const pixelBg = getComputedStyle(document.documentElement).getPropertyValue('--pixel-bg').trim();
+  
+  pixels.forEach(pixel => {
+    pixel.style.backgroundColor = pixelBg;
+  });
+}
+
+// Alternar tema
+function toggleTheme() {
+  const currentTheme = document.documentElement.getAttribute('data-theme');
+  const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+  
+  document.documentElement.setAttribute('data-theme', newTheme);
+  localStorage.setItem('pixel-art-theme', newTheme);
+}
+
+// Carregar tema
+function loadTheme() {
+  const savedTheme = localStorage.getItem('pixel-art-theme');
+  if (savedTheme) {
+    document.documentElement.setAttribute('data-theme', savedTheme);
+  }
+}
+
+// Alternar grade
+function toggleGrid() {
+  showGrid = !showGrid;
+  canvas.classList.toggle('no-grid', !showGrid);
+  
+  if (gridToggle) {
+    gridToggle.textContent = showGrid ? '🔲' : '⬜';
+    gridToggle.title = showGrid ? 'Ocultar Grade' : 'Mostrar Grade';
+  }
+}
+
+// Controle de zoom
+function changeZoom(delta) {
+  const newZoom = Math.max(50, Math.min(200, currentZoom + delta));
+  
+  if (newZoom !== currentZoom) {
+    // Remover classe de zoom anterior
+    canvas.classList.remove(`zoom-${currentZoom}`);
+    
+    currentZoom = newZoom;
+    
+    // Adicionar nova classe de zoom
+    if (currentZoom !== 100) {
+      canvas.classList.add(`zoom-${currentZoom}`);
+    }
+    
+    if (zoomLevel) {
+      zoomLevel.textContent = currentZoom + '%';
+    }
+  }
 }
 
 // Atualizar interface
 function updateSelectedColor(selectedColorElement) {
+  // Remover seleção anterior
   colorPalette.forEach(color => {
-    color.style.border = '1px solid #ccc';
-    color.style.transform = 'scale(1)';
+    color.classList.remove('selected');
   });
-  selectedColorElement.style.border = '3px solid #333';
-  selectedColorElement.style.transform = 'scale(1.1)';
+  
+  // Adicionar seleção atual
+  selectedColorElement.classList.add('selected');
 
   // Atualizar preview da cor atual
   const currentColorPreview = document.getElementById('current-color-preview');
@@ -98,23 +338,30 @@ function updateSelectedColor(selectedColorElement) {
 }
 
 function updateSelectedTool() {
+  // Remover seleção anterior
   tools.forEach(tool => {
-    tool.style.backgroundColor = '#f9f9f9';
-    tool.style.color = '#333';
-    tool.style.transform = 'scale(1)';
+    tool.classList.remove('active');
   });
+  
+  // Adicionar seleção atual
   const selectedTool = document.getElementById(currentTool + '-tool');
-  selectedTool.style.backgroundColor = '#007bff';
-  selectedTool.style.color = 'white';
-  selectedTool.style.transform = 'scale(1.05)';
+  if (selectedTool) {
+    selectedTool.classList.add('active');
+  }
 }
 
 // Inicializar interface
 function initializeUI() {
   // Selecionar primeira cor por padrão
-  const firstColor = colorPalette[0];
-  updateSelectedColor(firstColor);
+  if (colorPalette.length > 0) {
+    updateSelectedColor(colorPalette[0]);
+  }
 
   // Selecionar primeira ferramenta por padrão
   updateSelectedTool();
+  
+  // Configurar zoom inicial
+  if (zoomLevel) {
+    zoomLevel.textContent = currentZoom + '%';
+  }
 }

--- a/styles.css
+++ b/styles.css
@@ -5,16 +5,77 @@
     box-sizing: border-box;
 }
 
+:root {
+    --bg-color: #ffffff;
+    --text-color: #333333;
+    --header-bg: #f4f4f4;
+    --border-color: #ddd;
+    --button-bg: #f9f9f9;
+    --button-hover: #e0e0e0;
+    --canvas-bg: #f0f0f0;
+    --pixel-bg: #ffffff;
+    --pixel-border: #ddd;
+    --shadow-color: rgba(0, 0, 0, 0.1);
+    --accent-color: #007bff;
+}
+
+[data-theme="dark"] {
+    --bg-color: #1a1a1a;
+    --text-color: #ffffff;
+    --header-bg: #2d2d2d;
+    --border-color: #555;
+    --button-bg: #3d3d3d;
+    --button-hover: #4d4d4d;
+    --canvas-bg: #2a2a2a;
+    --pixel-bg: #333333;
+    --pixel-border: #555;
+    --shadow-color: rgba(0, 0, 0, 0.3);
+    --accent-color: #0d6efd;
+}
+
 body {
     font-family: Arial, sans-serif;
     line-height: 1.6;
-    color: #333;
+    color: var(--text-color);
+    background-color: var(--bg-color);
+    transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 header {
-    background-color: #f4f4f4;
+    background-color: var(--header-bg);
     padding: 1rem;
-    text-align: center;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    transition: background-color 0.3s ease;
+}
+
+.header-controls {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+}
+
+.theme-toggle {
+    background: none;
+    border: 2px solid var(--border-color);
+    color: var(--text-color);
+    font-size: 1.2rem;
+    padding: 0.5rem;
+    border-radius: 50%;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.theme-toggle:hover {
+    background-color: var(--button-hover);
+    transform: scale(1.1);
 }
 
 main {
@@ -29,30 +90,104 @@ main {
 section {
     margin-bottom: 2rem;
     padding: 1rem;
-    border: 1px solid #ddd;
+    border: 1px solid var(--border-color);
+    background-color: var(--bg-color);
+    border-radius: 8px;
+    box-shadow: 0 2px 4px var(--shadow-color);
+    transition: all 0.3s ease;
 }
 
 h1, h2 {
     margin-bottom: 1rem;
 }
 
-.tools {
+.canvas-header {
     display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+    flex-wrap: wrap;
     gap: 1rem;
 }
 
-.tools button {
-    padding: 0.5rem 1rem;
-    border: 1px solid #ccc;
-    background-color: #f9f9f9;
+.canvas-controls {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.canvas-controls button {
+    padding: 0.5rem;
+    border: 1px solid var(--border-color);
+    background-color: var(--button-bg);
+    color: var(--text-color);
     cursor: pointer;
     transition: all 0.2s ease;
     border-radius: 4px;
+    min-width: 40px;
+}
+
+.canvas-controls button:hover {
+    background-color: var(--button-hover);
+    transform: scale(1.05);
+}
+
+#zoom-level {
+    padding: 0.25rem 0.5rem;
+    font-weight: bold;
+    color: var(--text-color);
+    min-width: 50px;
+    text-align: center;
+}
+
+#canvas-container {
+    overflow: auto;
+    max-width: 100%;
+    border-radius: 8px;
+    background-color: var(--canvas-bg);
+    padding: 1rem;
+    display: flex;
+    justify-content: center;
+}
+
+.tools {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.tools button {
+    padding: 0.75rem 1rem;
+    border: 2px solid var(--border-color);
+    background-color: var(--button-bg);
+    color: var(--text-color);
+    cursor: pointer;
+    transition: all 0.2s ease;
+    border-radius: 8px;
+    font-weight: 500;
+    position: relative;
 }
 
 .tools button:hover {
     transform: scale(1.05);
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    box-shadow: 0 2px 4px var(--shadow-color);
+    background-color: var(--button-hover);
+}
+
+.tools button.active {
+    background-color: var(--accent-color);
+    color: white;
+    border-color: var(--accent-color);
+}
+
+.tool-info {
+    margin-top: 1rem;
+    padding: 0.5rem;
+    background-color: var(--canvas-bg);
+    border-radius: 4px;
+    font-size: 0.9rem;
+    color: var(--text-color);
 }
 
 .current-color-display {
@@ -90,26 +225,60 @@ h1, h2 {
 }
 
 .color {
-    width: 30px;
-    height: 30px;
-    border: 1px solid #ccc;
+    width: 40px;
+    height: 40px;
+    border: 2px solid var(--border-color);
     cursor: pointer;
     transition: all 0.2s ease;
-    border-radius: 4px;
+    border-radius: 6px;
+    position: relative;
 }
 
 .color:hover {
     transform: scale(1.1);
-    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    box-shadow: 0 2px 8px var(--shadow-color);
+}
+
+.color.selected {
+    border-color: var(--accent-color);
+    border-width: 3px;
+    transform: scale(1.1);
 }
 
 #pixel-canvas {
-    border: 2px solid #333;
+    border: 2px solid var(--border-color);
     display: grid;
     grid-template-columns: repeat(16, 20px);
     grid-template-rows: repeat(16, 20px);
     gap: 1px;
-    background-color: #f0f0f0;
+    background-color: var(--canvas-bg);
+    transition: transform 0.2s ease;
+    transform-origin: center;
+    user-select: none;
+}
+
+#pixel-canvas.zoom-125 {
+    transform: scale(1.25);
+}
+
+#pixel-canvas.zoom-150 {
+    transform: scale(1.5);
+}
+
+#pixel-canvas.zoom-200 {
+    transform: scale(2);
+}
+
+#pixel-canvas.zoom-75 {
+    transform: scale(0.75);
+}
+
+#pixel-canvas.zoom-50 {
+    transform: scale(0.5);
+}
+
+#pixel-canvas.no-grid .pixel {
+    border: none;
 }
 
 .demo-canvas {
@@ -133,20 +302,137 @@ h1, h2 {
 .pixel {
     width: 20px;
     height: 20px;
-    background-color: white;
-    border: 1px solid #ddd;
+    background-color: var(--pixel-bg);
+    border: 1px solid var(--pixel-border);
     cursor: pointer;
     transition: all 0.1s ease;
 }
 
 .pixel:hover {
-    border-color: #999;
-    transform: scale(1.05);
+    border-color: var(--accent-color);
+    box-shadow: inset 0 0 0 1px var(--accent-color);
 }
 
 footer {
-    background-color: #f4f4f4;
+    background-color: var(--header-bg);
     padding: 1rem;
     text-align: center;
     margin-top: 2rem;
+    transition: background-color 0.3s ease;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .container {
+        padding: 0 0.5rem;
+    }
+    
+    header {
+        flex-direction: column;
+        gap: 1rem;
+        text-align: center;
+    }
+    
+    .canvas-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    
+    .tools {
+        justify-content: center;
+    }
+    
+    .tools button {
+        padding: 0.5rem 0.75rem;
+        font-size: 0.9rem;
+    }
+    
+    .color-palette {
+        justify-content: center;
+    }
+    
+    .color {
+        width: 35px;
+        height: 35px;
+    }
+    
+    #pixel-canvas {
+        grid-template-columns: repeat(12, 18px);
+        grid-template-rows: repeat(12, 18px);
+    }
+    
+    .pixel {
+        width: 18px;
+        height: 18px;
+    }
+    
+    section {
+        padding: 0.75rem;
+        margin-bottom: 1rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .tools {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    
+    .tools button {
+        width: 100%;
+        text-align: center;
+    }
+    
+    .canvas-controls {
+        justify-content: center;
+    }
+    
+    #pixel-canvas {
+        grid-template-columns: repeat(10, 16px);
+        grid-template-rows: repeat(10, 16px);
+    }
+    
+    .pixel {
+        width: 16px;
+        height: 16px;
+    }
+    
+    .color {
+        width: 30px;
+        height: 30px;
+    }
+}
+
+/* Touch-friendly styles */
+@media (hover: none) and (pointer: coarse) {
+    .pixel:hover {
+        border-color: var(--pixel-border);
+        box-shadow: none;
+    }
+    
+    .pixel:active {
+        border-color: var(--accent-color);
+        box-shadow: inset 0 0 0 2px var(--accent-color);
+    }
+    
+    .tools button:hover {
+        transform: none;
+        box-shadow: none;
+    }
+    
+    .tools button:active {
+        transform: scale(0.95);
+        background-color: var(--accent-color);
+        color: white;
+    }
+    
+    .color:hover {
+        transform: none;
+        box-shadow: none;
+    }
+    
+    .color:active {
+        transform: scale(1.1);
+        box-shadow: 0 2px 8px var(--shadow-color);
+    }
 }


### PR DESCRIPTION
Introduces dark/light theme toggle, grid visibility, and zoom controls to the pixel art canvas. Adds keyboard shortcuts for tools, improves responsive design, and refactors UI for better usability on mobile and desktop. Implements flood fill, clear canvas, and touch support for drawing.

Kindly Accept My PR under hacktoberfest 2025 and don't forget to add labels for hacktoberfest-accepted and hacktoberfest.

### Here is the glimpse of dark mode functionality

<img width="1890" height="809" alt="image" src="https://github.com/user-attachments/assets/acf791ba-a860-406e-8c72-623af9673924" />
